### PR TITLE
feat: add hover to the card selection, hover and active states to pal…

### DIFF
--- a/app/style.css
+++ b/app/style.css
@@ -291,6 +291,14 @@ button:hover,
   border: 5px solid black;
 }
 
+.palette .active, .palette div:hover {
+  box-shadow: 0px 0px 10px 3px rgba(255,255,255, 1);
+}
+
+.palette div:hover {
+  cursor: pointer;
+}
+
 .image-frame {
   width: 100%;
   max-width: 400px;
@@ -521,6 +529,10 @@ button:hover,
   height: 100%;
   width: 100%;
   place-items: center;
+}
+
+.card:hover {
+  cursor: pointer;
 }
 
 .card:hover .author {

--- a/app/web_modules/DrawableCanvasElement.js
+++ b/app/web_modules/DrawableCanvasElement.js
@@ -43,11 +43,20 @@ export class DrawableCanvasElement {
 
     registerPaletteElements(paletteContainer) {
         const palette = document.getElementById(paletteContainer);
-        for (let colour of palette.children) {
-            colour.addEventListener('click', (event) => {
+
+        palette.addEventListener('click', (event) => {
+            if (event.target.id !== paletteContainer) {
+                for (let colour of palette.children) {
+                   colour.classList.remove('active');
+                }
+
+                event.target.classList.add('active');
                 this.setActiveColour(event.target.style["background-color"]);
-            });
-        }
+            }
+        });
+
+        palette.children[0].classList.add('active');
+
         return this;
     }
 


### PR DESCRIPTION
So this PR adds cursor icons to some of the hover states and adds an active state to the palette

<img width="415" alt="Screenshot 2020-10-20 at 20 36 34" src="https://user-images.githubusercontent.com/630034/96635848-54eca280-1314-11eb-8ed4-dba97de824be.png">


Would appreciate you opting this PR into Hacktoberfest by adding the label "hacktoberfest-accepted" please